### PR TITLE
[BUG] 루틴, 기록 뷰 탭 고정되는 오류 고침

### DIFF
--- a/Umpah-iOS/Umpah-iOS/Source/ViewControllers/MainVC.swift
+++ b/Umpah-iOS/Umpah-iOS/Source/ViewControllers/MainVC.swift
@@ -139,12 +139,12 @@ extension MainVC {
     }
     
     private func addClosureToChangeState(){
-        headerView.changeState = { isRecord in
-            //어떻게 하면 좋을지,,
-            if !isRecord{
+        headerView.changeState = { [weak self] isRoutine in
+            guard let self = self else { return }
+            if isRoutine && self.currentState != .routine {
                 self.cacheState = self.currentState
                 self.currentState = .routine
-            }else{
+            } else if !isRoutine {
                 self.currentState = self.cacheState
             }
             self.cardView.currentState = self.currentState

--- a/Umpah-iOS/Umpah-iOS/Source/Views/Components/Main/HeaderView.swift
+++ b/Umpah-iOS/Umpah-iOS/Source/Views/Components/Main/HeaderView.swift
@@ -74,7 +74,7 @@ class HeaderView: UIView {
         recordButton.titleLabel?.font = .IBMPlexSansSemiBold(ofSize: 16)
         routineButton.titleLabel?.font = .IBMPlexSansRegular(ofSize: 16)
         moveRecordDirection()
-        changeState?(true)
+        changeState?(false)
     }
     
     @objc
@@ -85,7 +85,7 @@ class HeaderView: UIView {
         routineButton.titleLabel?.font = .IBMPlexSansSemiBold(ofSize: 16)
         recordButton.titleLabel?.font = .IBMPlexSansRegular(ofSize: 16)
         moveRoutineDirection()
-        changeState?(false)
+        changeState?(true)
     }
 }
 


### PR DESCRIPTION
### 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- fix #71 

### 변경 사항 및 이유

<!-- 변경한 내용과 그 이유를 적어주세요. -->

루틴, 기록 뷰 이동 탭에서 나타나는 버그를 고쳤습니다.

### PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

루틴뷰와 기록뷰 탭 State를 변경하는 `addClosureToChangeState`함수에서 cacheState를 받기 때문에 루틴탭에 고정되어 버리는 오류가 생긴 거 같습니다. 
따라서 루틴뷰에 처음 들어왔을 때만 State 변경이 일어나고 루틴 뷰를 중복적으로 눌렀을 때 cacheState가 변경되지 않도록 구현했습니다.
기능 자체는 잘 되긴 하는데, 로직 자체가 이해하기 어렵고 난잡한 부분이 있어서 해당 부분은 이후에 수정을 하는 게 좋을 거 같습니다.

- PR #70 이 Closed되고 나서 코멘트 남겨주세요!

### 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->
![Simulator Screen Recording - iPhone 12 - 2022-02-09 at 13 20 22](https://user-images.githubusercontent.com/55099365/153121256-dc366cef-99c4-4b94-840f-b5b7f25bd869.gif)

